### PR TITLE
Streamline sign-up and payment

### DIFF
--- a/index.html
+++ b/index.html
@@ -807,16 +807,6 @@ section{
   background: linear-gradient(90deg, var(--blue-accent) 0%, var(--grey-medium) 50%);
 }
 
-/* Email input placeholder styling */
-#user-email::placeholder {
-  color: rgba(255, 255, 255, 0.6);
-}
-
-#user-email:focus {
-  outline: none;
-  border-color: var(--gold-premium);
-  background: rgba(255, 255, 255, 0.2);
-}
 
 /* Result animations */
 @keyframes celebrate {
@@ -1160,8 +1150,7 @@ section{
       <li><a href="#about">Crisis</a></li>
       <li><a href="#program">Masterclass</a></li>
       <li><a href="#value">Value</a></li>
-      <li><a href="#self-assess">Assessment</a></li>
-      <li><a href="#apply" class="btn btn-primary" style="padding:0.7rem 2rem; color:var(--white)">Apply Now</a></li>
+      <li><a href="http://revolut.me/victordelrosal" class="btn btn-primary" style="padding:0.7rem 2rem; color:var(--white)">Pay €195</a></li>
     </ul>
   </nav>
 </header>
@@ -1176,8 +1165,9 @@ section{
       <p class="hero-subtitle">
         A hands-on 5-week intensive generative AI masterclass for non-technical professionals and decision-makers.
       </p>
-      <div class="hero-cta" style="display: flex; justify-content: center;">
-        <a href="#apply" class="btn btn-gold">Claim Your Seat</a>
+      <div class="hero-cta" style="display: flex; flex-direction: column; align-items: center;">
+        <a href="http://revolut.me/victordelrosal" class="btn btn-gold">Pay €195 with Revolut</a>
+        <small style="margin-top:0.5rem;color:var(--grey-dark)">Special friends' discount, regular price €1,250</small>
       </div>
     </div>
   </div>
@@ -1515,178 +1505,12 @@ section{
   </div>
 </section>
 
-<!-- Self Assessment Section -->
-<section class="section section-light" id="self-assess" style="position: relative; overflow: hidden;">
-  <div class="section-pattern"></div>
-  
-  <!-- Floating background elements -->
-  <div class="assess-bg-element" style="position: absolute; top: -100px; right: -100px; width: 300px; height: 300px; background: radial-gradient(circle, var(--blue-glow) 0%, transparent 70%); animation: float 15s infinite ease-in-out;"></div>
-  <div class="assess-bg-element" style="position: absolute; bottom: -50px; left: -50px; width: 200px; height: 200px; background: radial-gradient(circle, var(--gold-glow) 0%, transparent 70%); animation: float 20s infinite ease-in-out reverse;"></div>
-  
-  <div class="container">
-    <div class="text-center mb-4 fade-in">
-      <h2 class="gradient-text">Is HELIOS Right for You?</h2>
-      <p class="lead">
-        Take this 30-second assessment to discover if you're ready<br>
-        to accelerate your AI transformation journey.
-      </p>
-    </div>
-    
-    <div class="assess-container" style="max-width: 800px; margin: 0 auto;">
-      <!-- Assessment Form -->
-      <form id="assessment-form" class="fade-in">
-        <div class="assess-card" style="background: var(--white); border-radius: 24px; padding: 3rem; box-shadow: var(--shadow-medium); margin-bottom: 2rem;">
-          
-          <!-- Question 1 -->
-          <div class="assess-question" style="margin-bottom: 3rem;">
-            <h3 style="font-size: 1.4rem; margin-bottom: 1.5rem; color: var(--black-soft);">
-              How proficient are you in the use of generative AI?
-            </h3>
-            <div class="slider-container">
-              <input type="range" id="q1" name="q1" min="1" max="3" value="2" class="custom-slider">
-              <div class="slider-labels" style="display: flex; justify-content: space-between; margin-top: 1rem; font-size: 0.9rem; color: var(--grey-dark);">
-                <span>Beginner<br><small style="opacity: 0.7;">Just starting</small></span>
-                <span style="text-align: center;">Intermediate<br><small style="opacity: 0.7;">Some experience</small></span>
-                <span style="text-align: right;">Advanced<br><small style="opacity: 0.7;">Power User</small></span>
-              </div>
-            </div>
-          </div>
-          
-          <!-- Question 2 -->
-          <div class="assess-question" style="margin-bottom: 3rem;">
-            <h3 style="font-size: 1.4rem; margin-bottom: 1.5rem; color: var(--black-soft);">
-              Can you commit to and connect to attending five 2.5 hr evening sessions on Wednesdays?
-            </h3>
-            <div class="slider-container">
-              <input type="range" id="q2" name="q2" min="1" max="3" value="2" class="custom-slider">
-              <div class="slider-labels" style="display: flex; justify-content: space-between; margin-top: 1rem; font-size: 0.9rem; color: var(--grey-dark);">
-                <span>Not really<br><small style="opacity: 0.7;">Difficult to commit</small></span>
-                <span style="text-align: center;">Maybe<br><small style="opacity: 0.7;">I'll try</small></span>
-                <span style="text-align: right;">Absolutely<br><small style="opacity: 0.7;">I'm in</small></span>
-              </div>
-            </div>
-          </div>
-          
-          <!-- Question 3 -->
-          <div class="assess-question" style="margin-bottom: 3rem;">
-            <h3 style="font-size: 1.4rem; margin-bottom: 1.5rem; color: var(--black-soft);">
-              Do you have satisfactory/average computer and online skills?
-            </h3>
-            <div class="slider-container">
-              <input type="range" id="q3" name="q3" min="1" max="3" value="2" class="custom-slider">
-              <div class="slider-labels" style="display: flex; justify-content: space-between; margin-top: 1rem; font-size: 0.9rem; color: var(--grey-dark);">
-                <span>I struggle with tech<br><small style="opacity: 0.7;">Need a lot of help</small></span>
-                <span style="text-align: center;">I get by<br><small style="opacity: 0.7;">Moderate comfort</small></span>
-                <span style="text-align: right;">Fully comfortable<br><small style="opacity: 0.7;">Can follow tutorials</small></span>
-              </div>
-            </div>
-          </div>
-          
-          <!-- Question 4 -->
-          <div class="assess-question" style="margin-bottom: 3rem;">
-            <h3 style="font-size: 1.4rem; margin-bottom: 1.5rem; color: var(--black-soft);">
-              Do you have your own computer (not a work laptop)?
-            </h3>
-            <div class="slider-container">
-              <input type="range" id="q4" name="q4" min="1" max="3" value="2" class="custom-slider">
-              <div class="slider-labels" style="display: flex; justify-content: space-between; margin-top: 1rem; font-size: 0.9rem; color: var(--grey-dark);">
-                <span>No<br><small style="opacity: 0.7;">Only work device</small></span>
-                <span style="text-align: center;">Not sure<br><small style="opacity: 0.7;">Possibly borrow one</small></span>
-                <span style="text-align: right;">Yes<br><small style="opacity: 0.7;">With admin rights</small></span>
-              </div>
-            </div>
-          </div>
-          
-          <button type="submit" class="btn btn-primary analyse-btn" style="width: 100%; font-size: 1.1rem; padding: 1.2rem; position: relative; overflow: hidden; background: linear-gradient(135deg, var(--blue-royal) 0%, var(--blue-accent) 100%); border: none; transform-style: preserve-3d; transition: all 0.3s ease;">
-            <span style="position: relative; z-index: 2;">Analyse My Readiness</span>
-            <div style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; background: linear-gradient(135deg, rgba(255,255,255,0.1) 0%, rgba(255,255,255,0) 100%); transform: translateY(50%) scale(2); opacity: 0; transition: opacity 0.3s ease, transform 0.3s ease;" class="btn-highlight"></div>
-          </button>
-        </div>
-      </form>
-      
-      <!-- Email Collection (Hidden Initially) -->
-      <div id="email-collection" class="assess-card fade-in" style="display: none; background: linear-gradient(135deg, var(--blue-deep) 0%, var(--blue-royal) 100%); border-radius: 24px; padding: 3rem; box-shadow: var(--shadow-deep); color: var(--white); text-align: center;">
-        <h3 style="color: var(--gold-premium); margin-bottom: 1rem;">Your Results Are Ready!</h3>
-        <p style="opacity: 0.9; margin-bottom: 2rem;">Enter your email to receive your personalized HELIOS readiness assessment.</p>
-        <form id="email-form">
-          <div style="position: relative; margin-bottom: 2rem;">
-            <input type="email" id="user-email" required placeholder="your@email.com" style="width: 100%; padding: 1.2rem 1.5rem; border-radius: 16px; border: 2px solid rgba(255,255,255,0.3); background: rgba(255,255,255,0.1); color: var(--white); font-size: 1.1rem; backdrop-filter: blur(10px);" />
-          </div>
-          <button type="submit" class="btn btn-gold submit-btn" style="width: 100%; font-size: 1.1rem; padding: 1.2rem; position: relative; overflow: hidden; background: linear-gradient(135deg, var(--gold-premium) 0%, var(--gold-rich) 100%); border: none; transform-style: preserve-3d; transition: all 0.3s ease;">
-            <span style="position: relative; z-index: 2;">Submit</span>
-            <div style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; background: linear-gradient(135deg, rgba(255,255,255,0.2) 0%, rgba(255,255,255,0) 100%); transform: translateY(50%) scale(2); opacity: 0; transition: opacity 0.3s ease, transform 0.3s ease;" class="btn-highlight"></div>
-          </button>
-        </form>
-      </div>
-      
-      <!-- Results (Hidden Initially) -->
-      <div id="assessment-results" class="assess-card fade-in" style="display: none; background: var(--white); border-radius: 24px; padding: 3rem; box-shadow: var(--shadow-deep); text-align: center; position: relative; overflow: hidden;">
-        <div class="result-animation" style="position: absolute; top: -50%; left: -50%; width: 200%; height: 200%; background: radial-gradient(circle, var(--gold-glow) 0%, transparent 50%); opacity: 0.3; animation: rotate 10s linear infinite;"></div>
-        <a href="#" id="back-to-assessment" style="position: absolute; top: 1.5rem; left: 1.5rem; color: var(--grey-dark); text-decoration: none; display: flex; align-items: center; font-size: 0.9rem; opacity: 0.7; transition: opacity 0.3s ease; z-index: 10;">
-          <span style="margin-right: 0.3rem;">↩️</span> Change answers
-        </a>
-        <div style="position: relative; z-index: 2;">
-          <div id="result-icon" style="font-size: 5rem; margin-bottom: 1.5rem;"></div>
-          <h3 id="result-title" style="font-size: 2.5rem; margin-bottom: 1rem;"></h3>
-          <p id="result-message" style="font-size: 1.2rem; line-height: 1.8; color: var(--grey-dark); margin-bottom: 2rem;"></p>
-          <div id="result-cta"></div>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
 <!-- Pricing -->
 <section class="section section-dark" id="pricing">
-  <div class="container">
-    <h2 class="text-center mb-4 fade-in">Choose Your Package</h2>
-    
-    <div class="pricing-grid" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(350px,1fr));gap:2rem;margin-top:3rem;">
-      
-      <div class="pricing-card slide-in-left">
-        <h3>Sirius</h3>
-        <p style="color:var(--grey-dark);margin-bottom:2rem">Essential transformation package</p>
-        <div class="price">€950</div>
-        <ul style="list-style:none;text-align:left;margin:2rem 0;line-height:2.2">
-          <li>✓ Access to the 5 Live Sessions</li>
-          <li>✓ Live Session Support</li>
-          <li>✓ Completion Certificate</li>
-          <li>✓ Booster Pack (6-month access)</li>
-          <li>✓ PDF copy of <em>HUMANLIKE: the AI Transformation</em> book</li>
-        </ul>
-        <a href="#apply" class="btn btn-secondary">Select Sirius</a>
-      </div>
-      
-      <div class="pricing-card featured fade-in">
-        <h3 style="color:var(--white)">Arcturus</h3>
-        <p style="color:rgba(255,255,255,0.8);margin-bottom:2rem">Complete transformation experience</p>
-        <div class="price">€1,250</div>
-        <ul style="list-style:none;text-align:left;margin:2rem 0;line-height:2.2;color:rgba(255,255,255,0.9)">
-          <li>✓ Everything in Sirius</li>
-          <li>✓ 1:1 Strategy Session (20 min)</li>
-          <li>✓ Offline Support</li>
-          <li>✓ Booster Pack (1-yr access)</li>
-          <li>✓ Physical copy of <em>HUMANLIKE: the AI Transformation</em> book signed by the author and posted to you</li>
-        </ul>
-        <a href="#apply" class="btn btn-gold">Choose Arcturus</a>
-      </div>
-      
-      <div class="pricing-card slide-in-right" style="position:relative;overflow:hidden;">
-        <h3>Betelgeuse</h3>
-        <p style="color:var(--grey-dark);margin-bottom:2rem">VIP transformation journey</p>
-        <div class="price">€2,500</div>
-        <ul style="list-style:none;text-align:left;margin:2rem 0;line-height:2.2">
-          <li>✓ Everything in Arcturus</li>
-          <li>✓ Two 1:1 Strategy Sessions (30 min)</li>
-          <li>✓ Priority Access & Support</li>
-          <li>✓ Booster Pack (lifetime access)</li>
-          <li>✓ Named HELIOS Founder status</li>
-          <li><strong style="color:var(--gold-premium)">Limited Seats Available.</strong></li>
-        </ul>
-        <a href="#apply" class="btn btn-secondary">Go VIP</a>
-      </div>
-      
-    </div>
+  <div class="container" style="text-align:center;">
+    <h2 class="text-center mb-4 fade-in">Secure Your Spot</h2>
+    <p class="lead" style="margin-bottom:2rem;">Pay €195 for the five sessions &mdash; regular price €1,250.</p>
+    <a href="http://revolut.me/victordelrosal" class="btn btn-gold">Pay with Revolut</a>
     
     <!-- Guarantee Section (Inside Pricing) -->
     <div class="container" style="margin-top: 4rem; margin-bottom: 4rem;">
@@ -2003,8 +1827,7 @@ section{
         <div style="line-height:2">
           <a href="#about" style="color:rgba(255,255,255,0.7);text-decoration:none;display:block">About</a>
           <a href="#program" style="color:rgba(255,255,255,0.7);text-decoration:none;display:block">Program</a>
-          <a href="#self-assess" style="color:rgba(255,255,255,0.7);text-decoration:none;display:block">Assessment</a>
-          <a href="#apply" style="color:rgba(255,255,255,0.7);text-decoration:none;display:block">Apply</a>
+          <a href="http://revolut.me/victordelrosal" style="color:rgba(255,255,255,0.7);text-decoration:none;display:block">Pay €195</a>
         </div>
       </div>
       <div>
@@ -2164,295 +1987,6 @@ document.querySelectorAll('.stat-item h3').forEach(stat => {
   statsObserver.observe(stat);
 });
 
-// Self Assessment Logic
-document.addEventListener('DOMContentLoaded', function() {
-  // Hide the pricing section initially
-  const pricingSection = document.getElementById('pricing');
-  pricingSection.style.display = 'none';
-  
-  const assessmentForm = document.getElementById('assessment-form');
-  const emailCollection = document.getElementById('email-collection');
-  const emailForm = document.getElementById('email-form');
-  const assessmentResults = document.getElementById('assessment-results');
-  const applyButton = document.getElementById('apply-button');
-  const backToAssessment = document.getElementById('back-to-assessment');
-  
-  // Check if assessment is already completed (stored in localStorage)
-  if (localStorage.getItem('helios_assessment_completed') === 'true') {
-    if (applyButton) {
-      applyButton.style.display = 'none';
-    }
-  }
-  
-  let assessmentScore = 0;
-  
-  // Back button functionality
-  if (backToAssessment) {
-    backToAssessment.addEventListener('click', function(e) {
-      e.preventDefault();
-      
-      // Hide results and show the assessment form again
-      assessmentResults.style.display = 'none';
-      assessmentForm.style.display = 'block';
-      
-      // Reset localStorage if needed
-      localStorage.removeItem('helios_assessment_completed');
-      
-      // Re-enable the apply button if it exists
-      if (applyButton) {
-        applyButton.style.display = 'inline-block';
-      }
-      
-      // Scroll back to the assessment form
-      assessmentForm.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    });
-  }
-  
-  // Update slider colors based on value
-  document.querySelectorAll('.custom-slider').forEach(slider => {
-    slider.addEventListener('input', function() {
-      updateSliderColor(this);
-    });
-    updateSliderColor(slider);
-  });
-  
-  function updateSliderColor(slider) {
-    const value = parseInt(slider.value);
-    slider.classList.remove('low-score', 'mid-score', 'high-score');
-    
-    if (value === 1) {
-      slider.classList.add('low-score');
-    } else if (value === 2) {
-      slider.classList.add('mid-score');
-    } else {
-      slider.classList.add('high-score');
-    }
-    
-    // Update track fill
-    const percent = ((value - 1) / 2) * 100;
-    const color = value === 1 ? '#ff6b6b' : value === 2 ? 'var(--gold-premium)' : 'var(--blue-accent)';
-    slider.style.background = `linear-gradient(90deg, ${color} 0%, ${color} ${percent}%, var(--grey-medium) ${percent}%, var(--grey-medium) 100%)`;
-  }
-  
-  // Handle assessment form submission
-  assessmentForm.addEventListener('submit', function(e) {
-    e.preventDefault();
-    
-    // Calculate score
-    const q1 = parseInt(document.getElementById('q1').value);
-    const q2 = parseInt(document.getElementById('q2').value);
-    const q3 = parseInt(document.getElementById('q3').value);
-    const q4 = parseInt(document.getElementById('q4').value);
-    
-    assessmentScore = q1 + q2 + q3 + q4;
-    
-    // Hide form, show email collection
-    assessmentForm.style.display = 'none';
-    emailCollection.style.display = 'block';
-    emailCollection.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  });
-  
-  // Handle email form submission
-  emailForm.addEventListener('submit', function(e) {
-    e.preventDefault();
-    
-    const userEmail = document.getElementById('user-email').value;
-    
-    // Hide email collection, show results
-    emailCollection.style.display = 'none';
-    assessmentResults.style.display = 'block';
-    
-    // Display results based on score
-    displayResults(assessmentScore, userEmail);
-    
-    // Simulate email send
-    simulateEmailSend(userEmail, assessmentScore);
-    
-    assessmentResults.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  });
-  
-  function displayResults(score, email) {
-    const resultIcon = document.getElementById('result-icon');
-    const resultTitle = document.getElementById('result-title');
-    const resultMessage = document.getElementById('result-message');
-    const resultCTA = document.getElementById('result-cta');
-    const pricingSection = document.getElementById('pricing');
-    
-    // Store that assessment was completed
-    localStorage.setItem('helios_assessment_completed', 'true');
-    
-    // Get individual question values
-    const q1 = parseInt(document.getElementById('q1').value); // AI proficiency
-    const q2 = parseInt(document.getElementById('q2').value); // Commitment to sessions
-    const q3 = parseInt(document.getElementById('q3').value); // Tech comfort
-    const q4 = parseInt(document.getElementById('q4').value); // Own computer
-    
-    // Check exclusion conditions:
-    // - Advanced user (q1 = 3)
-    // - Cannot commit to sessions (q2 = 1)
-    // - Struggles with tech (q3 = 1)
-    // - No own computer (q4 = 1)
-    if (q1 === 3 || q2 === 1 || q3 === 1 || q4 === 1) {
-      // Not suitable for HELIOS - don't show pricing section
-      pricingSection.style.display = 'none';
-      
-      resultIcon.innerHTML = '🌱';
-      resultTitle.innerHTML = 'HELIOS Is Not The Right Fit';
-      
-      // Customize message based on the specific reason(s)
-      let reasons = [];
-      if (q1 === 3) reasons.push("you're already at an advanced level");
-      if (q2 === 1) reasons.push("the program requires commitment to all five evening sessions");
-      if (q3 === 1) reasons.push("the program requires basic technical competency");
-      if (q4 === 1) reasons.push("you need access to your own computer");
-      
-      let reasonText = reasons.join(" and ");
-      
-      resultMessage.innerHTML = `Based on your responses, HELIOS isn't the best fit because ${reasonText}. We appreciate your interest in AI transformation and would be happy to recommend other resources that might better match your current situation.`;
-      resultCTA.innerHTML = `
-        <p style="margin-bottom: 1.5rem; color: var(--grey-dark);">We've sent some alternative recommendations to ${email}</p>
-        <a href="#" class="btn btn-secondary" onclick="alert('Resource guide would be sent here'); return false;">Explore Alternatives</a>
-      `;
-    } else if (score >= 10) {
-      // Perfect fit - show pricing section
-      pricingSection.style.display = 'block';
-      
-      resultIcon.innerHTML = '🚀';
-      resultTitle.innerHTML = '<span class="gradient-text">HELIOS is Perfect for You!</span>';
-      resultMessage.innerHTML = `You're ready to accelerate your AI journey. Your assessment shows you have the right mix of curiosity, readiness, and commitment to transform your capabilities in just 5 weeks.`;
-      resultCTA.innerHTML = `
-        <p style="margin-bottom: 1.5rem; font-weight: 600; color: var(--blue-electric);">Your personalized roadmap has been sent to ${email}</p>
-        <a href="#pricing" class="btn btn-primary" style="margin-right: 1rem;">Choose Your Package</a>
-        <a href="#program" class="btn btn-secondary">Review Program</a>
-      `;
-    } else if (score >= 7) {
-      // Good fit with guidance - show pricing section
-      pricingSection.style.display = 'block';
-      
-      resultIcon.innerHTML = '✨';
-      resultTitle.innerHTML = '<span style="color: var(--gold-premium);">HELIOS Can Transform You!</span>';
-      resultMessage.innerHTML = `You're at the perfect starting point for HELIOS. With our structured approach and expert guidance, you'll quickly bridge the gap between AI-curious and AI-capable.`;
-      resultCTA.innerHTML = `
-        <p style="margin-bottom: 1.5rem; font-weight: 600; color: var(--gold-rich);">Check ${email} for your readiness tips</p>
-        <a href="#pricing" class="btn btn-gold" style="margin-right: 1rem;">View Options</a>
-        <a href="#program" class="btn btn-secondary">Learn More</a>
-      `;
-    } else {
-      // Moderate score but no exclusion criteria - good fit with more preparation
-      pricingSection.style.display = 'block';
-      
-      resultIcon.innerHTML = '💡';
-      resultTitle.innerHTML = '<span style="color: var(--gold-premium);">You\'re Ready for HELIOS</span>';
-      resultMessage.innerHTML = `While you're still building your AI foundation, you meet all the key requirements for HELIOS. Our structured approach will help you quickly gain confidence and practical skills, even as a beginner.`;
-      resultCTA.innerHTML = `
-        <p style="margin-bottom: 1.5rem; color: var(--grey-dark);">We've sent some pre-course preparation tips to ${email}</p>
-        <a href="#pricing" class="btn btn-gold" style="margin-right: 1rem;">View Packages</a>
-        <a href="#program" class="btn btn-secondary">Learn More</a>
-      `;
-    }
-  }
-  
-  function simulateEmailSend(email, score) {
-    console.log('=== Simulating Email Send ===');
-    console.log('To:', email);
-    console.log('Subject: Your HELIOS Assessment Results');
-    console.log('Score:', score);
-    
-    let emailBody = `
-Dear Future AI Leader,
-
-Thank you for completing the HELIOS readiness assessment!
-
-Your Assessment Score: ${score}/12
-
-`;
-    
-    if (score >= 10) {
-      emailBody += `
-🚀 Congratulations! You're perfectly positioned for HELIOS.
-
-Based on your responses, you're ready to:
-- Transform from AI-curious to AI-capable in 5 weeks
-- Build real, working AI tools from day one
-- Save 20+ hours monthly through automation
-- Join an elite cohort of ambitious professionals
-
-Next Steps:
-1. Choose your transformation package (Sirius, Arcturus, or Betelgeuse)
-2. Complete your application before July 15, 2025
-3. Prepare for your AI transformation starting August 6
-
-Secure your seat: [Link to application]
-`;
-    } else if (score >= 7) {
-      emailBody += `
-✨ You're ready for transformation with HELIOS!
-
-Your assessment shows you have:
-- Strong interest in AI advancement
-- Readiness to learn with expert guidance
-- Commitment to practical application
-
-HELIOS is designed for professionals exactly like you. Our structured approach will help you:
-- Build confidence through hands-on projects
-- Master 5 essential AI tools
-- Create your own AI assistant
-- Network with like-minded professionals
-
-Ready to transform? View our packages: [Link to pricing]
-`;
-    } else {
-      emailBody += `
-🌱 Your AI journey is just beginning!
-
-While HELIOS is an intensive program for those ready to build immediately, we want to support your AI journey.
-
-Here are some resources to help you prepare:
-- Free AI Fundamentals Guide: [Link]
-- Introduction to Prompt Engineering: [Link]
-- AI Tools Comparison Chart: [Link]
-
-When you feel ready for intensive, hands-on AI mastery, HELIOS will be here for you.
-
-Stay curious!
-`;
-    }
-    
-    emailBody += `
-
-Best regards,
-The HELIOS Team
-
-P.S. Questions? Reply to this email or join our info session on July 20th.
-`;
-    
-    console.log('Body:', emailBody);
-    console.log('=== Email Send Complete ===');
-    
-    // Show a subtle notification
-    const notification = document.createElement('div');
-    notification.style.cssText = `
-      position: fixed;
-      bottom: 20px;
-      right: 20px;
-      background: linear-gradient(135deg, var(--blue-electric) 0%, var(--blue-accent) 100%);
-      color: white;
-      padding: 1rem 2rem;
-      border-radius: 50px;
-      box-shadow: var(--shadow-deep);
-      z-index: 9999;
-      animation: slideInRight 0.5s ease-out;
-    `;
-    notification.textContent = '✉️ Results sent to ' + email;
-    document.body.appendChild(notification);
-    
-    setTimeout(() => {
-      notification.style.animation = 'slideOutRight 0.5s ease-out';
-      setTimeout(() => notification.remove(), 500);
-    }, 3000);
-  }
-});
-</script>
 
 <!-- FAQ Accordion functionality -->
 <script>


### PR DESCRIPTION
## Summary
- remove assessment section and related script
- trim unused email styles
- add Revolut pay links in nav, hero, pricing section, and footer
- simplify pricing section to single payment option

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68611a99c8848324847c023e5fad6b0e